### PR TITLE
Dev cli

### DIFF
--- a/src/aria2tui/lib/aria2c_wrapper.py
+++ b/src/aria2tui/lib/aria2c_wrapper.py
@@ -119,6 +119,12 @@ def unpauseFull(gid, token=None):
     jsonreq["method"] = "aria2.unpause"
     return json.dumps(jsonreq).encode('utf-8')
 
+def unpauseAllFull(token=None):
+    jsonreq = { 'jsonrpc': '2.0', 'id': 'qwer', 'params' : [f"token:{token}"] }
+    jsonreq["params"] = [] if token in [None, ""] else [f"token:{token}"]
+    jsonreq["method"] = "aria2.unpauseAll"
+    return json.dumps(jsonreq).encode('utf-8')
+
 def removeFull(gid, token=None):
     jsonreq = { 'jsonrpc': '2.0', 'id': 'qwer', 'params' : [f"token:{token}"] }
     jsonreq["params"] = [] if token in [None, ""] else [f"token:{token}"]

--- a/src/aria2tui/utils/aria2c/cli.py
+++ b/src/aria2tui/utils/aria2c/cli.py
@@ -1,0 +1,270 @@
+#!/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+cli.py
+
+Command-line interface for aria2tui.
+
+---
+
+Called from the main app hook.
+
+If we handle an argument in cli mode then we exit. Otherwise we continue
+    to the TUI app loop.
+
+1. parse_args
+2. handle_cli_mode
+
+---
+
+Author: GrimAndGreedy
+License: MIT
+"""
+
+import os
+import sys
+import time
+import argparse
+import subprocess
+from typing import Tuple
+
+from listpick.listpick_app import start_curses, close_curses
+
+from aria2tui.utils.aria2c_utils import (
+    testConnection,
+    classify_download_string,
+    addDownload,
+    addTorrent,
+    sendReq,
+    get_config,
+    config_manager,
+)
+from aria2tui.utils.aria_adduri import addDownloadFull
+from aria2tui.utils.logging_utils import get_logger
+
+logger = get_logger()
+
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command-line arguments for aria2tui.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments
+    """
+    parser = argparse.ArgumentParser(
+        prog="aria2tui",
+        description="Terminal UI for aria2c download manager",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+
+    parser.add_argument(
+        "--conf",
+        metavar="INSTANCE",
+        dest="conf",
+        help="Specify config instance from aria2tui config. Specify instance index (0-indexed) or instance name.",
+    )
+
+    parser.add_argument(
+        "--add-download",
+        metavar="URI",
+        dest="add_download",
+        help="Add a download (magnet, HTTP, FTP, torrent file)",
+    )
+
+    parser.add_argument(
+        "--add-download-bg",
+        metavar="URI",
+        dest="add_download_bg",
+        help="Add a download in background mode (with gui prompt if connection isn't up). Useful for scripts not run directly from the command line.",
+    )
+
+    return parser.parse_args()
+
+def handle_download_addition_bg(uri: str) -> None:
+    """
+    Handle download addition in background mode with GUI prompts.
+
+    Args:
+        uri: The URI/path to add as a download
+    """
+    connection_up = testConnection()
+
+    if not connection_up:
+        exit_ = False
+        try:
+            import tkinter as tk
+            from tkinter import messagebox
+
+            # No main window
+            root = tk.Tk()
+            root.withdraw()
+
+            response = messagebox.askyesno(
+                "Aria2TUI", "Aria2c connection failed. Start daemon?"
+           )
+
+            if not response:
+                exit_ = True
+            else:
+                # Attempt to start aria2c
+                config = config_manager.get_current_instance()
+                for cmd in config["general"]["startup_commands"]:
+                    subprocess.run(
+                        cmd,
+                        shell=True,
+                        stderr=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                    )
+                time.sleep(0.1)
+
+        except Exception as e:
+            logger.exception("Error in background download flow: %s", e)
+            message = "Problem encountered. Download not added."
+            # os.system(f"notify-send '{message}'")
+            sys.exit(1)
+        finally:
+            if exit_:
+                message = "Exiting. Download not added."
+                # os.system(f"notify-send '{message}'")
+                sys.exit(0)
+
+            connection_up = testConnection()
+            if not connection_up:
+                message = "Problem encountered. Check your aria2tui config. Download not added."
+                # os.system(f"notify-send '{message}'")
+                sys.exit(1)
+
+    # Add the download
+    success, message = add_download_from_uri(uri)
+
+    # Send notification
+    # os.system(f"notify-send '{message}'")
+    sys.exit(0 if success else 1)
+
+
+def handle_download_addition(uri: str) -> None:
+    """
+    Handle download addition in foreground mode with TUI prompts.
+
+    Args:
+        uri: The URI/path to add as a download
+    """
+    from aria2tui.aria2tui_app import handleAriaStartPromt
+
+    connection_up = testConnection()
+
+    if not connection_up:
+        stdscr = start_curses()
+        handleAriaStartPromt(stdscr)
+        close_curses(stdscr)
+
+    # Add the download
+    success, message = add_download_from_uri(uri)
+
+    print(message)
+    sys.exit(0 if success else 1)
+
+
+def add_download_from_uri(uri: str) -> Tuple[bool, str]:
+    """
+    Add a download based on URI type.
+
+    Args:
+        uri: The URI/path to add (magnet, HTTP, FTP, metalink, or torrent file)
+
+    Returns:
+        Tuple of (success: bool, message: str)
+    """
+    dl_type = classify_download_string(uri)
+    logger.info("Adding download: uri=%s type=%s", uri, dl_type)
+
+    if dl_type in ["Magnet", "Metalink", "FTP", "HTTP"]:
+        try:
+            url, port, token = config_manager.get_url(), config_manager.get_port(), config_manager.get_token()
+            return_val, gid = addDownloadFull(
+                uri=uri,
+                token=token,
+                url=url,
+                port=int(port)
+            )
+            if return_val:
+                message = f"Success! download added: gid={gid}."
+                return True, message
+            else:
+                message = "Error adding download."
+                return False, message
+        except Exception as e:
+            logger.exception("Error adding download '%s': %s", uri, e)
+            return False, "Error adding download."
+
+    elif dl_type == "Torrent File":
+        try:
+            js_req = addTorrent(uri)
+            sendReq(js_req)
+            message = "Torrent added successfully."
+            return True, message
+        except Exception as e:
+            logger.exception("Error adding torrent file '%s': %s", uri, e)
+            return False, "Error adding torrent."
+
+    else:
+        logger.error("Unrecognized download type for uri: %s", uri)
+        return False, "Error: unrecognized download type."
+
+
+def handle_cli_mode(args: argparse.Namespace) -> bool:
+    """
+    Handle CLI-only mode (non-interactive download additions).
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        True if CLI mode was handled (app should exit), False if TUI mode should start
+    """
+    config_set = False
+
+    if args.conf:
+        if not args.conf.isdigit():
+            try:
+                ind = config_manager.get_instance_names().index(args.conf)
+                config_manager.switch_instance(ind)
+
+            except ValueError:
+                print(f"No config instance named {args.conf}.\nExiting...")
+                return True
+        else:
+            ## Config specified by name
+            ind = int(args.conf)
+            if 0 <= ind < config_manager.get_instance_count():
+                config_manager.switch_instance(ind)
+            else:
+                print(f"Config instance {ind} not in range.\nExiting...")
+                return True
+
+        print(f"Config set to {config_manager.get_current_instance()['name']}")
+
+        config_set = True
+
+    # Handle background download addition
+    if args.add_download_bg:
+        handle_download_addition_bg(args.add_download_bg)
+        return True
+
+    # Handle foreground download addition
+    if args.add_download:
+        handle_download_addition(args.add_download)
+        return True
+
+    if config_set: return True
+    # No CLI mode specified, continue to TUI
+    return False


### PR DESCRIPTION
refs #13 

We now use argparse to handle command line arguments. We have added the ability to specify which instance you wish to use. 

# CLI Enhancements

### Download Management:
- --add_download URI - Add a single download (magnet, HTTP, FTP, torrent)
- --add_download_bg URI - Add download in background mode (GUI prompt for daemon)
- --input_file FILE - Batch add downloads from aria2c-compatible input file
### Download Control:
- --pause GID - Pause a specific download
- --pause_all - Pause all active downloads
- --resume GID - Resume a specific download
- --resume_all - Resume all paused downloads
- --clear - Clear completed/errored downloads
Configuration:
- --conf INSTANCE - Switch between configured aria2c instances

## Input File Format
Supports aria2c's native input file format with URLs, options, and comments:
```
# Comment
https://example.com/file.iso
    filename.iso
    dir=/home/user/Downloads/
    pause=true
```